### PR TITLE
Fix: Correct CSS stylesheet filename typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>World Clock - GitHub MCP Demo</title>
-    <link rel="stylesheet" href="styls.css">
+    <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
## Summary
Fixes critical bug where website displayed without styling due to incorrect stylesheet filename reference.

## Changes
- Fixed typo in `index.html` line 7: `styls.css` → `styles.css`

## Impact
- Restores all CSS styling to the World Clock application
- Fixes 404 error on stylesheet loading

## Testing
- Verified file reference now matches actual filename `styles.css`
- Confirmed website displays correctly with full styling

Fixes #4